### PR TITLE
fix auth for settings requests

### DIFF
--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -84,7 +84,9 @@ export const requestFromAPI = async <T>(
 
   try {
     options = withSecurityOptions(options, isBrowser);
-    options = await withAuth(options, isBrowser);
+    if (!endpoint.endsWith('api/v1/settings')) {
+      options = await withAuth(options, isBrowser);
+    }
 
     const response = await request(url, options);
     const body = await response.json();

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -5,7 +5,7 @@ import type { LayoutData, LayoutLoad } from './$types';
 import { fetchCluster, fetchSystemInfo } from '$lib/services/cluster-service';
 import { fetchNamespaces } from '$lib/services/namespaces-service';
 import { fetchSettings } from '$lib/services/settings-service';
-import { getAuthUser, setAuthUser } from '$lib/stores/auth-user';
+import { clearAuthUser, getAuthUser, setAuthUser } from '$lib/stores/auth-user';
 import type { GetClusterInfoResponse, GetSystemInfoResponse } from '$lib/types';
 import type { Settings } from '$lib/types/global';
 import {
@@ -21,6 +21,11 @@ export const load: LayoutLoad = async function ({
   fetch,
 }): Promise<LayoutData> {
   const settings: Settings = await fetchSettings(fetch);
+
+  if (!settings.auth.enabled) {
+    cleanAuthUserCookie();
+    clearAuthUser();
+  }
 
   const authUser = getAuthUserCookie();
   if (authUser?.accessToken) {


### PR DESCRIPTION
## Description & motivation 💭

An invalid value for `AuthUser` set in browser `localStorage` breaks the Temporal UI.

![Screenshot 2024-04-08 at 10.47.15 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GhSXS9HmjwUhdM34i8zD/8751d981-e82c-46f8-887c-2d773ecc904a.png)

This change exempts the settings endpoint from passing auth as its response is used to determine if auth is needed. It also clears stale tokens when auth is disabled by the server.

This is mostly a concern for local development or for UI servers running without authentication.

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

The `requestFromAPI` should probably have a `withAuth` parameter but that change is more involved.

## Testing 🧪

```
# repro

# navigate to http://localhost:8081

# from chrome console

# breaks
localStorage.setItem("AuthUser", "foobar")

# fixes 
localStorage.clear()
```

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->