### PR TITLE
use origin for callback

### DIFF
--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -51,7 +51,6 @@ type Auth struct {
 	IssuerURL        string
 	AuthorizationURL string
 	ClientID         string
-	CallbackURL      string
 	Scopes           []string
 	Options          []string
 }
@@ -133,7 +132,6 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 				IssuerURL:        authProviderCfg.IssuerURL,
 				AuthorizationURL: authProviderCfg.AuthorizationURL,
 				ClientID:         authProviderCfg.ClientID,
-				CallbackURL:      authProviderCfg.CallbackURL,
 				Scopes:           authProviderCfg.Scopes,
 				Options:          options,
 			},

--- a/server/server/config/auth.go
+++ b/server/server/config/auth.go
@@ -60,6 +60,9 @@ func (c *AuthProvider) validate() error {
 		if c.AuthorizationURL != "" {
 			return errors.New("auth endpoint url is not used in auth code flow")
 		}
+		if c.CallbackURL == "" {
+			return errors.New("auth callback url is not set")
+		}
 	case "implicit":
 		// TODO: support oidc discovery in implicit flow
 		if c.ProviderURL != "" {
@@ -72,16 +75,16 @@ func (c *AuthProvider) validate() error {
 		if c.ClientSecret != "" {
 			return errors.New("no secrets in implicit flow")
 		}
+		if c.CallbackURL != "" {
+			return errors.New("auth callback url is not used in implicit flow")
+		}
+
 	default:
 		return errors.New("auth oidc flow is not valid")
 	}
 
 	if c.ClientID == "" {
 		return errors.New("auth client id is not set")
-	}
-
-	if c.CallbackURL == "" {
-		return errors.New("auth callback url is not set")
 	}
 
 	return nil

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -93,23 +93,23 @@ type (
 	}
 
 	AuthProvider struct {
-		// Optional. Label for the provider
+		// Optional. Label for the provider.
 		Label string `yaml:"label"`
-		// Type of the auth provider. Only OIDC is supported today
+		// Type of the auth provider. Only OIDC is supported today.
 		Type string `yaml:"type"`
-		// OIDC login flow type. The "authorization-code" and "implicit" flows are supported
+		// OIDC login flow type. The "authorization-code" and "implicit" flows are supported.
 		Flow string `yaml:"flow"`
 		// OIDC .well-known/openid-configuration URL, e.g. https://accounts.google.com/. Discovery unsupported in implicit flow.
 		ProviderURL string `yaml:"providerUrl"`
 		// Optional. Needed only when differs from the auth provider URL. In implicit flow, enables token issuer validation.
 		IssuerURL string `yaml:"issuerUrl"`
-		// Required for implicit flow. OIDC authorization endpoint URL, e.g. https://accounts.google.com/o/oauth2/v2/auth
+		// Required for implicit flow. OIDC authorization endpoint URL, e.g. https://accounts.google.com/o/oauth2/v2/auth.
 		AuthorizationURL string `yaml:"authorizationUrl"`
 		ClientID         string `yaml:"clientId"`
 		ClientSecret     string `yaml:"clientSecret"`
 		// Scopes for auth. Typically [openid, profile, email]
 		Scopes []string `yaml:"scopes"`
-		// URL for the callback, e.g. https://localhost:8080/sso/callback
+		// URL for the callback, e.g. https://localhost:8080/sso/callback. Not used in the implicit flow.
 		CallbackURL string `yaml:"callbackUrl"`
 		// Options added as URL query params when redirecting to auth provider. Can be used to configure custom auth flows such as Auth0 invitation flow.
 		Options map[string]interface{} `yaml:"options"`

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -25,7 +25,6 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
       issuerUrl: settingsResponse?.Auth?.IssuerURL,
       authorizationUrl: settingsResponse?.Auth?.AuthorizationURL,
       clientId: settingsResponse?.Auth?.ClientID,
-      callbackUrl: settingsResponse?.Auth?.CallbackURL,
       scopes: settingsResponse?.Auth?.Scopes,
       options: settingsResponse?.Auth?.Options,
     },

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -82,7 +82,6 @@ export type Settings = {
     issuerUrl: string;
     authorizationUrl: string;
     clientId: string;
-    callbackUrl: string;
     scopes: string[];
     options: string[];
   };

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -209,7 +209,6 @@ export type SettingsResponse = {
     IssuerURL: string;
     AuthorizationURL: string;
     ClientID: string;
-    CallbackURL: string;
     Scopes: string[];
     Options: string[];
   };

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -250,7 +250,7 @@ const routeForImplicitFlow = (
   const authorizationUrl = new URL(settings.auth.authorizationUrl);
   authorizationUrl.searchParams.set('response_type', 'id_token');
   authorizationUrl.searchParams.set('client_id', settings.auth.clientId);
-  authorizationUrl.searchParams.set('redirect_uri', settings.auth.callbackUrl);
+  authorizationUrl.searchParams.set('redirect_uri', originUrl);
   authorizationUrl.searchParams.set('scope', settings.auth.scopes.join(' '));
 
   const nonce = crypto.randomUUID();


### PR DESCRIPTION
tsia. the client can simply use the origin for the implicit flow.

```
    - label: oidc implicit flow
      type: oidc
      flow: implicit
      # TODO: support optional issuer validation
      authorizationUrl: https://dev-95856544.okta.com/oauth2/v1/authorize  # discovery isn't supported for implicit flow. the endpoint must be provided directly
      clientId: 0oag5vkuazxXyvuel5d7
      scopes:
        - openid
        - profile
        - email
```